### PR TITLE
SBDEV-3704 rate limiting

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name            'logicmonitor-logicmonitor'
-version         '2.0.2'
+version         '2.0.3'
 summary         'Automate monitoring of your devices with LogicMonitor'
 description     'This Puppet module allows you to automate management of collectors, devices, and device groups in your
                  LogicMonitor portal via Puppet version 4.'

--- a/lib/puppet/provider/logicmonitor.rb
+++ b/lib/puppet/provider/logicmonitor.rb
@@ -104,7 +104,16 @@ class Puppet::Provider::Logicmonitor < Puppet::Provider
     else
       http = connection
     end
-    download_collector ? http.request(request).body : JSON.parse(http.request(request).body)
+
+    response = http.request(request)
+
+    if response.status == 429
+      debug "Error: Request Rate Limited, sleep 1 minute, retry"
+      sleep 60
+      return rest(connection, endpoint, http_method, query_params, data, download_collector)
+    end
+
+    download_collector ? response.body : JSON.parse(response.body)
   end
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "logicmonitor-logicmonitor",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Samuel Dacanay",
   "license": "Apache-2.0",
   "summary": "A module for managing LogicMonitor devices, device groups, and collectors",


### PR DESCRIPTION
If we receive the rate limit response code (documented here as 429: https://confluence.logicmonitor.com/display/DEV/API+Throttler+Design+Specification#APIThrottlerDesignSpecification-ResponseHeaderisrelatedtoAPILimitation)

We should sleep for one minute then retry the request. Per Product Requirement, there should be no retry limit.