### PR TITLE
SBDEV-4033: remove verify_none mode for ssl requests

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name            'logicmonitor-logicmonitor'
-version         '2.0.6'
+version         '2.0.7'
 summary         'Automate monitoring of your devices with LogicMonitor'
 description     'This Puppet module allows you to automate management of collectors, devices, and device groups in your
                  LogicMonitor portal via Puppet version 4.'

--- a/lib/puppet/provider/logicmonitor.rb
+++ b/lib/puppet/provider/logicmonitor.rb
@@ -109,7 +109,6 @@ class Puppet::Provider::Logicmonitor < Puppet::Provider
     if connection.nil?
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       http.start
     else
       http = connection

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "logicmonitor-logicmonitor",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": "Samuel Dacanay",
   "license": "Apache-2.0",
   "summary": "A module for managing LogicMonitor devices, device groups, and collectors",


### PR DESCRIPTION
Note this will require client certificate verification of logicmonitor to pass